### PR TITLE
Use fs.realpath to handle nvm symlink proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
+const fs = require('fs');
 const globalDirs = require('global-dirs');
 const isPathInside = require('is-path-inside');
 
-module.exports = isPathInside(__dirname, globalDirs.yarn.packages) || isPathInside(__dirname, globalDirs.npm.packages);
+module.exports = isPathInside(__dirname, globalDirs.yarn.packages) || isPathInside(__dirname, fs.realpathSync(globalDirs.npm.packages));


### PR DESCRIPTION
At least on windows (not sure of other platforms), [nvm](https://github.com/coreybutler/nvm-windows), will use symlink proxying to make things work and look natural.

But since symlink lives somewhere else on file system, `__dirname !~= 'C:\Program Files\nodejs...'` but more so `__dirname ~= 'C:\Users\...\AppData\nvm\v7.0.0\...'`