### PR TITLE
Fix missing global directory issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const globalDirs = require('global-dirs');
 const isPathInside = require('is-path-inside');
 
-module.exports = (function () {
+module.exports = (() => {
 	try {
 		return (
 			isPathInside(__dirname, globalDirs.yarn.packages) ||

--- a/index.js
+++ b/index.js
@@ -3,7 +3,13 @@ const fs = require('fs');
 const globalDirs = require('global-dirs');
 const isPathInside = require('is-path-inside');
 
-module.exports =
-	isPathInside(__dirname, globalDirs.yarn.packages) ||
-	(fs.existsSync(globalDirs.npm.packages) &&
-		isPathInside(__dirname, fs.realpathSync(globalDirs.npm.packages)));
+module.exports = (function () {
+	try {
+		return (
+			isPathInside(__dirname, globalDirs.yarn.packages) ||
+			isPathInside(__dirname, fs.realpathSync(globalDirs.npm.packages))
+		);
+	} catch (_) {
+		return false;
+	}
+})();

--- a/index.js
+++ b/index.js
@@ -5,4 +5,5 @@ const isPathInside = require('is-path-inside');
 
 module.exports =
 	isPathInside(__dirname, globalDirs.yarn.packages) ||
-	isPathInside(__dirname, fs.realpathSync(globalDirs.npm.packages));
+	(fs.existsSync(globalDirs.npm.packages) &&
+		isPathInside(__dirname, fs.realpathSync(globalDirs.npm.packages)));

--- a/test.js
+++ b/test.js
@@ -9,8 +9,17 @@ import packageJson from './package.json';
 import fixturePackageJson from './fixture/package.json';
 import isInstalledGlobally from '.';
 
-test('local', t => {
+test.serial('local', t => {
 	t.false(isInstalledGlobally);
+});
+
+test.serial('missing global folder', t => {
+	const packages = '/some/non-existing/path';
+	delete require.cache[require.resolve('.')];
+	const clone = JSON.parse(JSON.stringify(globalDirs));
+	Object.assign(globalDirs, {yarn: {packages}, npm: {packages}});
+	t.throws(() => require('.'), {code: 'ENOENT', message: /lstat '\/some'/});
+	Object.assign(globalDirs, clone);
 });
 
 test('global', async t => {

--- a/test.js
+++ b/test.js
@@ -9,17 +9,17 @@ import packageJson from './package.json';
 import fixturePackageJson from './fixture/package.json';
 import isInstalledGlobally from '.';
 
-test.serial('local', t => {
-	t.false(isInstalledGlobally);
-});
-
-test.serial('missing global folder', t => {
+test.serial('regression: missing global folder', t => {
 	const packages = '/some/non-existing/path';
 	delete require.cache[require.resolve('.')];
 	const clone = JSON.parse(JSON.stringify(globalDirs));
 	Object.assign(globalDirs, {yarn: {packages}, npm: {packages}});
 	t.false(isInstalledGlobally);
 	Object.assign(globalDirs, clone);
+});
+
+test('local', t => {
+	t.false(isInstalledGlobally);
 });
 
 test('global', async t => {

--- a/test.js
+++ b/test.js
@@ -18,7 +18,7 @@ test.serial('missing global folder', t => {
 	delete require.cache[require.resolve('.')];
 	const clone = JSON.parse(JSON.stringify(globalDirs));
 	Object.assign(globalDirs, {yarn: {packages}, npm: {packages}});
-	t.throws(() => require('.'), {code: 'ENOENT', message: /lstat '\/some'/});
+	t.false(isInstalledGlobally);
 	Object.assign(globalDirs, clone);
 });
 

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ import packageJson from './package.json';
 import fixturePackageJson from './fixture/package.json';
 import isInstalledGlobally from '.';
 
-test.serial('regression: missing global folder', t => {
+test.serial('regression: missing global directory', t => {
 	const packages = '/some/non-existing/path';
 	delete require.cache[require.resolve('.')];
 	const clone = JSON.parse(JSON.stringify(globalDirs));


### PR DESCRIPTION
Fixes #4
Fixes #6

I recently wiped my laptop and migrated to using `fish` and `fish-nvm`.
I now and don't have a global npm ("node_modules") folder anymore (personal preference 🙈, using yarn only).

Installing some packages led to the the following errors:
```
error /redacted/node_modules/@prisma/cli: Command failed.
Exit code: 1
Command: node preinstall/index.js
Arguments: 
Directory: /redacted/node_modules/@prisma/cli
Output:
internal/fs/utils.js:220
    throw err;
    ^

Error: ENOENT: no such file or directory, lstat '/usr/local/lib/node_modules'
    at Object.realpathSync (fs.js:1529:7)
    at Object.794 (/redacted/node_modules/@prisma/cli/preinstall/index.js:1:53017)
    at __webpack_require__ (/redacted/node_modules/@prisma/cli/preinstall/index.js:1:154)
    at Object.500 (/redacted/node_modules/@prisma/cli/preinstall/index.js:1:30472)
    at __webpack_require__ (/redacted/node_modules/@prisma/cli/preinstall/index.js:1:154)
    at startup (/redacted/node_modules/@prisma/cli/preinstall/index.js:1:291)
    at module.exports.8 (/redacted/node_modules/@prisma/cli/preinstall/index.js:1:346)
    at Object.<anonymous> (/redacted/node_modules/@prisma/cli/preinstall/index.js:1:356)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10) {
  errno: -2,
  syscall: 'lstat',
  code: 'ENOENT',
  path: '/usr/local/lib/node_modules'
```
[source](https://github.com/prisma/prisma/blob/2.0.0-beta.1/cli/prisma2/scripts/preinstall.js) | [compiled](https://unpkg.com/browse/@prisma/cli@2.0.0-beta.1/preinstall/index.js)

---

the problem is that the code calls to `realpathSync` before it knows it really exists. so I added a check there.

It's my first time touching `ava` again in a long time, and I don't know a cleaner way to mock modules, suggestions welcome.