### PR TITLE
Update global-dirs to v3.0.0 to resolve Github issue CVE-2020-7788

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=8"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -39,7 +39,7 @@
 		"binary"
 	],
 	"dependencies": {
-		"global-dirs": "^2.0.1",
+		"global-dirs": "^3.0.0",
 		"is-path-inside": "^3.0.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Upgrade global-dirs package to v3.0.0.

Resolves #9 Upgrade "global-dirs" dependency to the latest version